### PR TITLE
Use regenerator-runtime package

### DIFF
--- a/5.js
+++ b/5.js
@@ -2,11 +2,11 @@
 if (!global._egruntime_installed) {
     global._egruntime_installed = 5;
     require("core-js/shim");
-    require("regenerator/runtime");
+    require("regenerator-runtime/runtime");
     require("./lib");
 }
 else if (global._egruntime_installed == 6) {
     global._egruntime_installed = 5;
     require("core-js/shim");
-    require("regenerator/runtime");
+    require("regenerator-runtime/runtime");
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib.js",
   "dependencies": {
     "core-js": "^0.9.18",
-    "regenerator": "^0.8.32",
+    "regenerator-runtime": "^0.9.5",
     "kaiser": ">=0.0.4"
   },
   "scripts": {


### PR DESCRIPTION
The regenerator package warns when requiring "regenerator/runtime" that the module is deprecated, and to use "regenerator-runtime/runtime" instead.
