### PR TITLE
Update core-js dependency to 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Runtime for the Earl Grey programming language.",
   "main": "./lib.js",
   "dependencies": {
-    "core-js": "^0.9.18",
+    "core-js": "^2.4.0",
     "regenerator-runtime": "^0.9.5",
     "kaiser": ">=0.0.4"
   },


### PR DESCRIPTION
Going through the change log for core-js, nothing seems to have changed between 0.9.18 and 2.4.0 that should break Earl Grey. Nothing in the runtime uses a feature that was significantly changed or removed in core-js that I can tell. The full two-iteration bootstrap of Earl Grey itself works fine, and all its tests pass. All of Quaint's tests pass as well. My own projects are unaffected by the upgrade.
